### PR TITLE
Input date ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-date/styles.js
+++ b/source/components/input-date/styles.js
@@ -46,6 +46,8 @@ export default (
       border: `thin solid ${isInvalid ? colors.danger : colors.lightGrey}`,
       boxShadow: isInvalid ? `0 0 5px ${colors.danger}` : 'none',
       borderRadius: rhythm(radiuses.small),
+      appearance: 'none',
+      lineHeight: rhythm(1.35),
       ...treatments.input,
 
       '&:focus': {


### PR DESCRIPTION
Styling issues with date input component in iOS:
https://drive.google.com/file/d/1K4V-9zMLoXaNMJlIL1p9zA1Dry-dq3wG/view

This commit removed appearance property and add line height to deal with iOS:
https://drive.google.com/file/d/1Ab8xPCWlLw8aYjWQY7-4URhzg4dE-RVF/view