### PR TITLE
Update grey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/lib/traits/index.js
+++ b/source/lib/traits/index.js
@@ -15,7 +15,7 @@ export const scale = (exponent = 0, scale = 1.2) =>
 export const colors = {
   light: '#fff',
   dark: '#000',
-  grey: '#7a898f',
+  grey: '#4F595F',
   lightGrey: '#aec0c6',
   paleGrey: '#ebf1f3',
   primary: '#1bab6b',


### PR DESCRIPTION
Small update to darken our default grey color. Currently this fails WCAG AA and AAA requirements.
![fail](https://user-images.githubusercontent.com/18586149/125319547-7ce7c000-e300-11eb-8568-3a9b25021792.png)

Updating color to pass AAA requirements. If we are only concerned with meeting AA and want a lighter grey color we could use #68767D and pass AA. But went ahead and darkened so we would pass AAA