### PR TITLE
Prevent letters and special chars in tel input

### DIFF
--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -5,6 +5,7 @@ import merge from 'lodash/merge'
 import withStyles from '../with-styles'
 import styles from './styles'
 import { isBoolean } from '../../lib/form'
+import { regularExpressions } from '../../lib/validators'
 import sanitizeHtml from '../../lib/sanitizeHtml'
 
 import ContentEditable from 'react-contenteditable'
@@ -56,10 +57,35 @@ class InputField extends React.Component {
     return onBlur && onBlur(value)
   }
 
+  handlePhoneKeyDown (event) {
+    const validKeys = [
+      ' ',
+      'Alt',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'Backspace',
+      'Control',
+      'Enter',
+      'Escape',
+      'Shift',
+      'Tab'
+    ]
+    const isPhoneChar = regularExpressions.phone.test(event.key)
+    const isValidKey = isPhoneChar || validKeys.indexOf(event.key) > -1
+
+    if (!event.metaKey && !isValidKey) {
+      event.preventDefault()
+    }
+  }
+
   handleKeyDown (event) {
     const { onKeyDown, type } = this.props
 
     onKeyDown && onKeyDown(event)
+
+    if (type === 'tel') this.handlePhoneKeyDown(event)
 
     if (type === 'contenteditable' && event.metaKey) {
       switch (event.key) {

--- a/source/lib/validators/index.js
+++ b/source/lib/validators/index.js
@@ -3,7 +3,7 @@ export const regularExpressions = {
   alphaNumeric: /^[A-Za-z0-9]+$/i,
   alphaNumericSpecial: /^[A-Za-z0-9'_./#&+-\s]+$/i,
   passwordComplexity: /^(?:(?=.*\W)(?=.*[a-zA-Z])(?=.*\d))/,
-  phone: /^\({0,1}((0|\+61)(2|4|3|7|8)){0,1}\){0,1}( |-){0,1}[0-9]{2}( |-){0,1}[0-9]{2}( |-){0,1}[0-9]{1}( |-){0,1}[0-9]{3}$/,
+  phone: /^[\d\-+.*#()]/,
   slug: /^[A-Za-z0-9-]+$/i,
   url: /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-/]))?/
 }


### PR DESCRIPTION
On most mobile browsers, an `<input type="tel" />` brings up a special software keyboard which only allows the user to enter numbers and/or a couple of phone number specific characters (+, #, *, etc). On desktop however, there's generally no special treatment. This change prevents input of for all characters except numbers and and a handful of special characters that are used in valid phone numbers – I looked at a bunch of mobile browser software keyboards to get a list.

**Note:** This updates the existing `phone` validator to make it more useful, which was only useful for Australian phone number format, [added back in the heady days of 2017](https://github.com/blackbaud-services/constructicon/commit/5dfbc256ff65831091686b6c45099aa5da639ea6#diff-a8744419d8b3b0e0deb0d3037a22b50e1ec23af3388dc711413323874d3f379aR9). My guess is a copy/paste from 40HF, JRFH or maybe MyMarathon? I had a look and it's not in use in any current projects anymore, so this update may make it useful again. It is just checking for allowed characters, not a pattern.