### PR TITLE
Do not prefill date selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-date/__tests__/InputDate-test.js
+++ b/source/components/input-date/__tests__/InputDate-test.js
@@ -95,4 +95,54 @@ describe('InputDate', () => {
       done()
     }, 500)
   })
+
+  it('should not set date if only month is selected', done => {
+    let dateValue
+
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-date'
+        value={dateValue}
+        showSelects
+        onChange={value => (dateValue = value)}
+      />
+    )
+    const input = wrapper.find('select').at(1)
+    input.simulate('change', { target: { value: 1 } })
+
+    // need to wait for callback to debounce
+    setTimeout(() => {
+      expect(dateValue).to.eql(undefined)
+      done()
+    }, 500)
+  })
+
+  it('should set date if day, month and year are all selected', done => {
+    let dateValue
+
+    const wrapper = mount(
+      <InputDate
+        label='Test Field'
+        name='test-date'
+        value={dateValue}
+        showSelects
+        onChange={value => (dateValue = value)}
+      />
+    )
+
+    const dayInput = wrapper.find('select').at(0)
+    const monthInput = wrapper.find('select').at(1)
+    const yearInput = wrapper.find('select').at(2)
+
+    dayInput.simulate('change', { target: { value: 2 } })
+    monthInput.simulate('change', { target: { value: 1 } })
+    yearInput.simulate('change', { target: { value: 2022 } })
+
+    // need to wait for callback to debounce
+    setTimeout(() => {
+      expect(dateValue).to.eql('2022-02-02')
+      done()
+    }, 500)
+  })
 })

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -18,11 +18,17 @@ class InputDate extends Component {
     this.updateDateFragment = this.updateDateFragment.bind(this)
     this.updateDate = this.updateDate.bind(this)
 
+    const date = dayjs(props.value || props.default)
+
     this.state = {
-      touched: !!props.value,
       showSelects: props.showSelects,
       value: props.value,
-      date: props.value ? dayjs(props.value) : dayjs(props.default)
+      date,
+      fragments: {
+        date: props.value ? date.date().toString() : '',
+        month: props.value ? date.month().toString() : '',
+        year: props.value ? date.year().toString() : ''
+      }
     }
   }
 
@@ -42,16 +48,30 @@ class InputDate extends Component {
 
   updateDateFragment (type) {
     return value => {
-      if (!value) {
-        return
+      if (!value) return
+
+      const fragments = {
+        ...this.state.fragments,
+        [type]: value
       }
 
-      return this.updateDate(this.state.date[type](value))
+      const { date, month, year } = fragments
+
+      this.setState({ fragments })
+
+      if (date && month && year) {
+        return this.updateDate(
+          this.state.date
+            .date(date)
+            .month(month)
+            .year(year)
+        )
+      }
     }
   }
 
   updateDate (date) {
-    this.setState({ date, touched: true })
+    this.setState({ date })
     this.props.onChange(dayjs(date).format('YYYY-MM-DD'))
   }
 
@@ -67,7 +87,7 @@ class InputDate extends Component {
       validations
     } = this.props
 
-    const { showSelects, touched, date = dayjs() } = this.state
+    const { showSelects, date = dayjs() } = this.state
 
     const labelId = `label-${id || name}`
     const allowedProps = pick(this.props, [
@@ -112,7 +132,7 @@ class InputDate extends Component {
           <InputSelect
             {...allowedProps}
             styles={styles.input}
-            value={touched ? date.date().toString() : ''}
+            value={this.state.fragments.date}
             onChange={this.updateDateFragment('date')}
             onBlur={this.updateDateFragment('date')}
             label='Day'
@@ -126,7 +146,7 @@ class InputDate extends Component {
           <InputSelect
             {...allowedProps}
             styles={styles.input}
-            value={touched ? date.month().toString() : ''}
+            value={this.state.fragments.month}
             onChange={this.updateDateFragment('month')}
             onBlur={this.updateDateFragment('month')}
             label='Month'
@@ -137,7 +157,7 @@ class InputDate extends Component {
           <InputSelect
             {...allowedProps}
             styles={styles.input}
-            value={touched ? date.year().toString() : ''}
+            value={this.state.fragments.year}
             onChange={this.updateDateFragment('year')}
             onBlur={this.updateDateFragment('year')}
             label='Year'


### PR DESCRIPTION
Prevents first date input selection filling out the other select fields. Previously they were autofilled with default values of 1 Jan 1980.

This was an unintended and kinda lazy outcome because we needed a valid moment/dayjs object. This change means that we don't set the date value until all 3 selects have a value.

![date](https://user-images.githubusercontent.com/729085/127414884-d6630055-fba8-4056-80c4-9a5bdf6c4a9e.gif)

![date-validation](https://user-images.githubusercontent.com/729085/127415020-de2bab6c-f3b6-4261-8b71-779fe5e0f0c4.gif)
