### PR TITLE
Change position of label/input for checkbox and radios to aid accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -203,6 +203,8 @@ class InputField extends React.Component {
 
     return (
       <div className={`c11n-input-field ${classNames.root}`}>
+        {isBoolean(type) && renderField()}
+
         {label && (
           <Label
             id={labelId}
@@ -217,7 +219,7 @@ class InputField extends React.Component {
           </Label>
         )}
 
-        {renderField()}
+        {!isBoolean(type) && renderField()}
 
         {['textarea', 'contenteditable'].indexOf(type) > -1 &&
           !!maxLength && (


### PR DESCRIPTION
Because the label came before the input, any anchors in the label would be focused before the input, even though the input had been moved before the label via CSS.

**Before**

![before](https://user-images.githubusercontent.com/729085/130557462-eabf4b88-6c3c-4c34-9852-88b698544f88.gif)

**After**

![after](https://user-images.githubusercontent.com/729085/130557480-fff4f8cc-5490-4a27-8505-121248cd702b.gif)
