### PR TITLE
A11y updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -165,7 +165,7 @@ class InputDate extends Component {
             aria-labelledby={labelId}
             options={[
               { label: 'Year', value: '', disabled: true },
-              ...mapValues(range(1900, parseInt(dayjs().year() + 1)))
+              ...mapValues(range(1900, parseInt(dayjs().year() + 1)).reverse())
             ]}
           />
         </div>

--- a/source/components/input-date/index.js
+++ b/source/components/input-date/index.js
@@ -92,8 +92,10 @@ class InputDate extends Component {
     const labelId = `label-${id || name}`
     const allowedProps = pick(this.props, [
       'disabled',
+      'invalid',
       'placeholder',
-      'required'
+      'required',
+      'touched'
     ])
     const months = [
       { label: 'January', value: 0 },

--- a/source/components/input-field/styles.js
+++ b/source/components/input-field/styles.js
@@ -13,7 +13,7 @@ export default (
     root: {
       display: 'block',
       position: 'relative',
-      paddingLeft: checkbox ? rhythm(1) : '0',
+      paddingLeft: checkbox ? rhythm(1.25) : '0',
       fontFamily: fonts.body,
       textAlign: 'left',
       marginBottom: rhythm(1),
@@ -24,7 +24,17 @@ export default (
       ? {
         position: 'absolute',
         top: rhythm(0.125),
-        left: 0
+        left: 0,
+        width: rhythm(0.75),
+        height: rhythm(0.75),
+        border: `thin solid ${isInvalid ? colors.danger : colors.lightGrey}`,
+        boxShadow: isInvalid ? `0 0 5px ${colors.danger}` : 'none',
+        borderRadius: rhythm(radiuses.small),
+
+        '&:focus': {
+          borderColor: isInvalid ? colors.danger : colors.secondary,
+          boxShadow: `0 0 5px ${isInvalid ? colors.danger : colors.secondary}`
+        }
       }
       : {
         display: 'block',

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -10,6 +10,14 @@ import Icon from '../icon'
 import InputValidations from '../input-validations'
 import Label from '../label'
 
+const isIos = () => {
+  if (typeof window !== 'undefined' && !!navigator) {
+    return !window.MSStream && /iPad|iPhone|iPod/.test(navigator.userAgent)
+  }
+
+  return false
+}
+
 const InputSelect = ({
   classNames,
   error,
@@ -69,11 +77,21 @@ const InputSelect = ({
 
       return resultOptions
     } else {
-      return options.map(({ value, label, disabled }, index) => (
-        <option value={value} key={index} disabled={disabled}>
-          {label}
-        </option>
-      ))
+      // Hack for long labels on iOS
+      const hasLongOptionLabel = options.reduce((acc, option) => {
+        return acc || option.label.length > 32
+      }, false)
+
+      return (
+        <React.Fragment>
+          {options.map(({ value, label, disabled }, index) => (
+            <option value={value} key={index} disabled={disabled}>
+              {label}
+            </option>
+          ))}
+          {isIos() && hasLongOptionLabel && <optgroup label='' />}
+        </React.Fragment>
+      )
     }
   }
 

--- a/source/components/label/styles.js
+++ b/source/components/label/styles.js
@@ -9,7 +9,7 @@ export default (
       display: 'block',
       fontWeight: 700,
       fontSize: scale(-0.5),
-      lineHeight: measures.medium,
+      lineHeight: '1.5em',
       textAlign: 'left',
       marginBottom: rhythm(0.25),
       ...treatments.label,


### PR DESCRIPTION
- Reverse order of date input years (most recent at top)
![](https://user-images.githubusercontent.com/729085/131965714-00d04636-fc7f-445a-b27c-3b22501d244d.png)

- Show invalid styles for date input selects (red borders)
  
![](https://user-images.githubusercontent.com/729085/131965711-4dcc9ef4-8bdf-4f86-831e-795eb8f65d38.png)

- Improvements to checkbox/radio styles – red box shadows, and increase width/height when browser supports it. We could revisit this one more thoroughly in future.
  ![](https://user-images.githubusercontent.com/729085/131965719-31ef9cb4-2bf2-421e-9c72-ffc72e39e709.png)

- Improve readability of long select option labels on iOS

![ios](https://user-images.githubusercontent.com/729085/131966448-9b9d5a37-d303-4978-a1f0-4a9c594a03ec.png)
