### PR TITLE
Number input updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-field/index.js
+++ b/source/components/input-field/index.js
@@ -80,13 +80,39 @@ class InputField extends React.Component {
     }
   }
 
+  handleNumberKeyDown (event) {
+    const validKeys = [
+      'Alt',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'Backspace',
+      'Control',
+      'Enter',
+      'Escape',
+      'Shift',
+      'Tab'
+    ]
+
+    const isNumberChar = regularExpressions.numeric.test(event.key)
+    const isValidKey =
+      event.key === '.'
+        ? event.target.value.indexOf('.') < 0
+        : isNumberChar || validKeys.indexOf(event.key) > -1
+
+    if (!event.metaKey && !isValidKey) {
+      event.preventDefault()
+    }
+  }
+
   handleKeyDown (event) {
     const { onKeyDown, type } = this.props
 
     onKeyDown && onKeyDown(event)
 
     if (type === 'tel') this.handlePhoneKeyDown(event)
-
+    if (type === 'number') this.handleNumberKeyDown(event)
     if (type === 'contenteditable' && event.metaKey) {
       switch (event.key) {
         case 'u':

--- a/source/lib/validators/index.js
+++ b/source/lib/validators/index.js
@@ -2,6 +2,7 @@ export const regularExpressions = {
   alpha: /^[A-Za-z]+$/i,
   alphaNumeric: /^[A-Za-z0-9]+$/i,
   alphaNumericSpecial: /^[A-Za-z0-9'_./#&+-\s]+$/i,
+  numeric: /^[0-9.]+$/i,
   passwordComplexity: /^(?:(?=.*\W)(?=.*[a-zA-Z])(?=.*\d))/,
   phone: /^[\d\-+.*#()]/,
   slug: /^[A-Za-z0-9-]+$/i,


### PR DESCRIPTION
Some desktop browsers (e.g. Chrome & Edge) restrict user input for number inputs to only numbers and number-related characters (e.g. `. + - e` are allowed but in a certain order only).

I've attempted too mimic a subset of those features for all browsers, by only allowing numbers (0-9) and a single `.` char for decimal place. I'm assuming we won't need +/- etc.