### PR TITLE
add hooks to get window and element dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/use-dimensions/Readme.md
+++ b/source/components/use-dimensions/Readme.md
@@ -1,0 +1,14 @@
+A hook to return the dimensions of a ref passed in the hook. Can pass liveMeasure prop as false to prevent from recalculting on resize. Will return the following props of the element:
+*width, height, top, left, x, y, right, bottom*
+
+### Example
+Setting padding based on height of another div
+
+```javascript static
+  const [ref, { height }] = useDimensions()
+  return (
+    <div>
+      <div style={{ paddingBottom: height }} />
+      <div className={classNames.wrapper} ref={ref} />
+    </div>
+```

--- a/source/components/use-dimensions/index.js
+++ b/source/components/use-dimensions/index.js
@@ -1,0 +1,49 @@
+import { useState, useCallback, useEffect } from 'react'
+
+const getDimensionObject = node => {
+  const rect = node.getBoundingClientRect()
+
+  return {
+    width: rect.width,
+    height: rect.height,
+    top: 'x' in rect ? rect.x : rect.top,
+    left: 'y' in rect ? rect.y : rect.left,
+    x: 'x' in rect ? rect.x : rect.left,
+    y: 'y' in rect ? rect.y : rect.top,
+    right: rect.right,
+    bottom: rect.bottom
+  }
+}
+
+const useDimensions = (data = null, liveMeasure = true) => {
+  const [dimensions, setDimensions] = useState({})
+  const [node, setNode] = useState(null)
+
+  const ref = useCallback(node => {
+    setNode(node)
+  }, [])
+
+  useEffect(() => {
+    if (node) {
+      const measure = () =>
+        window.requestAnimationFrame(() =>
+          setDimensions(getDimensionObject(node))
+        )
+      measure()
+
+      if (liveMeasure) {
+        window.addEventListener('resize', measure)
+        window.addEventListener('scroll', measure)
+
+        return () => {
+          window.removeEventListener('resize', measure)
+          window.removeEventListener('scroll', measure)
+        }
+      }
+    }
+  }, [node, data])
+
+  return [ref, dimensions, node]
+}
+
+export default useDimensions

--- a/source/components/use-window-size/Readme.md
+++ b/source/components/use-window-size/Readme.md
@@ -1,0 +1,13 @@
+A simple hook to return the dimensions of window size by width and height. Can be used if need to account for screen resizing.
+
+### Example
+
+```javascript static
+const windowSize = useWindowSize()
+<div>
+  window width is {windowSize.width}
+</div>
+<div>
+  window height is {windowSize.height}
+</div>
+```

--- a/source/components/use-window-size/__tests__/index.js
+++ b/source/components/use-window-size/__tests__/index.js
@@ -1,0 +1,22 @@
+import useWindowSize from '..'
+
+const UseWindowExample = () => {
+  const { width, height } = useWindowSize()
+  return <div width={width} height={height} />
+}
+
+describe('useWindowSize hook', () => {
+  it('returns width as a number', () => {
+    const wrapper = mount(<UseWindowExample />)
+    const div = wrapper.find('div')
+    const width = div.prop('width')
+    expect(width).to.be.a('number')
+  })
+
+  it('returns height as a number', () => {
+    const wrapper = mount(<UseWindowExample />)
+    const div = wrapper.find('div')
+    const width = div.prop('height')
+    expect(width).to.be.a('number')
+  })
+})

--- a/source/components/use-window-size/index.js
+++ b/source/components/use-window-size/index.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined
+  })
+  useEffect(() => {
+    function handleResize () {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    handleResize()
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+  return windowSize
+}
+
+export default useWindowSize

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -111,6 +111,19 @@ module.exports = {
       ])
     },
     {
+      name: 'Hooks',
+      sections: [
+        {
+          name: 'useDimensions',
+          content: 'source/components/use-dimensions/Readme.md'
+        },
+        {
+          name: 'useWindowSize',
+          content: 'source/components/use-window-size/Readme.md'
+        }
+      ]
+    },
+    {
       name: 'Higher Order Components',
       sections: [
         {


### PR DESCRIPTION
Add in a couple hooks that were used in DUK that may be useful elsewhere:
1.  useWindowSize - simple hook to get back dimensions of window
2. useDimensions - return dimensions of element ref. 

Still need to add unit test for useDimensions, having a bit of trouble testing this since utilizes window.requestAnimationFrame and that does not really do anything when testing and not actually in the DOM.

Since this is first set of hooks we are using in c11n, open to suggestions in terms of formatting and standardizing what return. Might make more sense to standardize responses on data fetching hooks and not worry about it so much here.

