### PR TITLE
Check prop deep equality in pagination component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/pagination/index.js
+++ b/source/components/pagination/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import chunk from 'lodash/chunk'
+import isEqual from 'lodash/isEqual'
 
 export default class Pagination extends Component {
   constructor () {
@@ -18,7 +19,7 @@ export default class Pagination extends Component {
   componentDidUpdate (prevProps) {
     const { toPaginate } = this.props
 
-    if (toPaginate !== prevProps.toPaginate) {
+    if (!isEqual(toPaginate, prevProps.toPaginate)) {
       if (this.props.persistPage) {
         this.setState({
           allPages: this.paginate(toPaginate)


### PR DESCRIPTION
Previously it was checking for strict equality, which would only be true if that prop hadn't changed at all (i.e. exact same array, but another prop had changed).

In my case the array/data was _exactly_ the same, but was a new JS object so it didn't match.