### PR TITLE
Remove lodash template dependency in progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/progress-bar/__tests__/ProgressBar-test.js
+++ b/source/components/progress-bar/__tests__/ProgressBar-test.js
@@ -9,9 +9,7 @@ import {
   treatments
 } from '../../../lib/traits'
 
-const minimalComponent = mount(
-  <ProgressBar progress={50} alt='<%= progress %>% raised' />
-)
+const minimalComponent = mount(<ProgressBar progress={50} alt='50% raised' />)
 
 describe('ProgressBar', () => {
   it('should render an alt text', () => {
@@ -40,7 +38,7 @@ describe('ProgressBar', () => {
     const wrapper = mount(
       <ProgressBar
         progress={50}
-        alt='<%= progress %>% raised'
+        alt='50% raised'
         background='secondary'
         fill='dark'
         radius='none'
@@ -60,7 +58,7 @@ describe('ProgressBar', () => {
     const wrapper = mount(
       <ProgressBar
         progress={50}
-        alt='<%= progress %>% raised'
+        alt='50% raised'
         styles={{
           fill: {
             background: '#123456'

--- a/source/components/progress-bar/index.js
+++ b/source/components/progress-bar/index.js
@@ -2,23 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import withStyles from '../with-styles'
 import styles from './styles'
-import template from 'lodash/template'
-
-const altTemplate = (str, progress) => {
-  const compileTemplate = template(str)
-  return compileTemplate({ progress })
-}
 
 const ProgressBar = ({ classNames, alt, progress = 0 }) => (
   <div className={`c11n-progress-bar ${classNames.root}`}>
     <div className={classNames.fill} aria-hidden />
-    <div className={classNames.alt}>{altTemplate(alt, progress)}</div>
+    <div className={classNames.alt}>{alt}</div>
   </div>
 )
 
 ProgressBar.propTypes = {
   /**
-   * The alt text for the progress bar. Takes a `progress` value in a valid [Lodash Template](https://lodash.com/docs/4.17.4#template). E.g. `'<%= progress %>% there'`
+   * The alt text for the progress bar.
    */
   alt: PropTypes.string.isRequired,
 

--- a/source/components/progress-bar/readme.md
+++ b/source/components/progress-bar/readme.md
@@ -6,7 +6,7 @@ A half filled progress bar.
 
 ```
 <ProgressBar
-  alt='<%= progress %>% raised'
+  alt='50% raised'
   progress={50}
 />
 ```
@@ -17,7 +17,7 @@ Uses custom colors and radiuses as specified by traits
 
 ```
 <ProgressBar
-  alt='<%= progress %>% raised'
+  alt='50% raised'
   progress={50}
   background='secondary'
   fill='dark'
@@ -36,7 +36,7 @@ For example, using a gradient for the progress fill:
 
 ```
 <ProgressBar
-  alt='<%= progress %>% raised'
+  alt='50% raised'
   progress={50}
   styles={{
     fill: {


### PR DESCRIPTION
Because of the use of [`Function`](https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14870) in the [`lodash/template`](https://lodash.com/docs/4.17.15#template) method, it caused issues with a Content-Security-Policy not allowing the `unsafe-eval` directive.

It wasn't an integral part of the component, so I'm just removing it.