### PR TITLE
Flip image from camera input by default

### DIFF
--- a/source/components/icon/Readme.md
+++ b/source/components/icon/Readme.md
@@ -55,6 +55,10 @@
 ```
 
 ```
+<Icon name='flip' />
+```
+
+```
 <Icon name='heart' />
 ```
 

--- a/source/components/icon/icons.js
+++ b/source/components/icon/icons.js
@@ -241,6 +241,13 @@ export const euro = [
   }
 ]
 
+export const flip = [
+  {
+    d:
+      'M15.071 2v26h-13l13-26Zm-1.857 7.867L5.076 26.143h8.138V9.867ZM16.93 2v26h13l-13-26Z'
+  }
+]
+
 export const heart = [
   {
     d:

--- a/source/components/input-image/index.js
+++ b/source/components/input-image/index.js
@@ -25,6 +25,7 @@ class InputImage extends React.Component {
     this.handleSetImage = this.handleSetImage.bind(this)
     this.setRef = this.setRef.bind(this)
     this.state = {
+      flip: false,
       height: props.height,
       image:
         props.value && props.value.indexOf('base64') > -1 ? props.value : null,
@@ -76,7 +77,7 @@ class InputImage extends React.Component {
   handleStartCamera () {
     const { width, height } = this.props
 
-    this.setState({ input: 'camera', loading: true })
+    this.setState({ input: 'camera', flip: true, loading: true })
 
     navigator.mediaDevices
       .getUserMedia({
@@ -116,6 +117,11 @@ class InputImage extends React.Component {
     this.canvas.width = width
     this.canvas.height = height
 
+    if (this.state.flip) {
+      context.translate(context.canvas.width, 0)
+      context.scale(-1, 1)
+    }
+
     context.drawImage(this.video, 0, 0, width, height)
 
     this.canvas.toBlob(
@@ -130,12 +136,14 @@ class InputImage extends React.Component {
 
   handleClearImage (event) {
     const { width, height, onChange } = this.props
+    const isCameraInput = this.state.input === 'camera'
 
     event.preventDefault()
 
-    if (this.state.input === 'camera') this.handleStartCamera()
+    if (isCameraInput) this.handleStartCamera()
 
     this.setState({
+      flip: isCameraInput,
       height,
       image: null,
       orientation: height > width ? 'portrait' : 'landscape',
@@ -239,6 +247,7 @@ class InputImage extends React.Component {
     } = this.props
 
     const {
+      flip,
       height,
       image,
       input,
@@ -252,7 +261,8 @@ class InputImage extends React.Component {
     // Style fix for Firefox not respecting aspect ratio options
     const videoStyles = {
       width: `${(settings.width / settings.height) * 100}%`,
-      left: `${(100 - (settings.width / settings.height) * 100) / 2}%`
+      left: `${(100 - (settings.width / settings.height) * 100) / 2}%`,
+      transform: flip && 'scaleX(-1)'
     }
 
     return (
@@ -359,6 +369,20 @@ class InputImage extends React.Component {
                   <Loading />
                 </div>
               )}
+              <Button
+                background='transparent'
+                foreground='dark'
+                effect='grow'
+                spacing={0}
+                onClick={() => this.setState({ flip: !flip })}
+                styles={styles.flip}
+              >
+                <Icon
+                  name='flip'
+                  size={1.5}
+                  styles={{ transform: flip && 'scaleX(-1)' }}
+                />
+              </Button>
             </div>
             <Button {...buttonProps} onClick={this.handleCaptureImage}>
               Capture photo

--- a/source/components/input-image/styles.js
+++ b/source/components/input-image/styles.js
@@ -180,8 +180,17 @@ export default (props, traits) => {
       left: 0,
       width: '100%',
       height: '100%',
-      backgroundColor: 'rgba(0,0,0,0.5)',
-      transform: 'scaleX(-1)'
+      backgroundColor: 'rgba(0,0,0,0.5)'
+    },
+
+    flip: {
+      position: 'absolute',
+      bottom: 0,
+      right: 0,
+      zIndex: 1,
+      color: 'white',
+      padding: '0.5rem',
+      filter: 'drop-shadow(1px 1px 1px rgba(0,0,0,0.25))'
     },
 
     loading: {


### PR DESCRIPTION
![flipped](https://user-images.githubusercontent.com/729085/146854633-5bdfb6fa-5a2f-46ac-9fd8-f17ee7f5718a.gif)

With an overlay especially, but even without one the instant feedback from the camera input to the captured image is jarring. 

So instead now we flip the image captured via camera input (matches the preview which is flipped) with an option to _unflip_ the image during camera preview.