### PR TITLE
2659698 elastic search feedback - scrollbar and safari fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constructicon",
-  "version": "4.4.12-0",
+  "version": "4.4.12-1",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/input-select/index.js
+++ b/source/components/input-select/index.js
@@ -58,23 +58,55 @@ const InputSelect = ({
 
       mapKeys(groupedOptions, (opts, groupLabel) => {
         if (groupLabel !== 'undefined') {
-          resultOptions.push(
-            <optgroup key={groupLabel} label={groupLabel}>
-              {opts.map(({ value, label, disabled }, index) => (
+          if (elasticSearch) {
+            resultOptions.push(
+              <div role='optgroup' key={groupLabel} label={groupLabel}>
+                {opts.map(({ value, label, disabled }, index) => (
+                  <p
+                    role='option'
+                    data-value={value}
+                    key={index}
+                    disabled={disabled}
+                  >
+                    {label}
+                  </p>
+                ))}
+              </div>
+            )
+          } else {
+            resultOptions.push(
+              <optgroup key={groupLabel} label={groupLabel}>
+                {opts.map(({ value, label, disabled }, index) => (
+                  <option value={value} key={index} disabled={disabled}>
+                    {label}
+                  </option>
+                ))}
+              </optgroup>
+            )
+          }
+        } else {
+          if (elasticSearch) {
+            resultOptions.push(
+              opts.map(({ value, label, disabled }, index) => (
+                <p
+                  role='option'
+                  data-value={value}
+                  key={index}
+                  disabled={disabled}
+                >
+                  {label}
+                </p>
+              ))
+            )
+          } else {
+            resultOptions.push(
+              opts.map(({ value, label, disabled }, index) => (
                 <option value={value} key={index} disabled={disabled}>
                   {label}
                 </option>
-              ))}
-            </optgroup>
-          )
-        } else {
-          resultOptions.push(
-            opts.map(({ value, label, disabled }, index) => (
-              <option value={value} key={index} disabled={disabled}>
-                {label}
-              </option>
-            ))
-          )
+              ))
+            )
+          }
         }
       })
 
@@ -95,7 +127,27 @@ const InputSelect = ({
         return acc || option.label.length > 32
       }, false)
 
-      return filteredOptions.length ? (
+      return elasticSearch ? (
+        filteredOptions.length ? (
+          <>
+            {filteredOptions.map(({ value, label, disabled }, index) => (
+              <p
+                role='option'
+                data-value={value}
+                key={index}
+                disabled={disabled}
+              >
+                {label}
+              </p>
+            ))}
+            {isIos() && hasLongOptionLabel && <div label='' role='optgroup' />}
+          </>
+        ) : (
+          <p role='option' disabled>
+            {nonIdealElasticSearchResult}
+          </p>
+        )
+      ) : filteredOptions.length ? (
         <>
           {filteredOptions.map(({ value, label, disabled }, index) => (
             <option value={value} key={index} disabled={disabled}>
@@ -155,12 +207,13 @@ const InputSelect = ({
             />
             {showResults && (
               <div
-                aria-roledescription='select'
+                role='select'
                 className={classNames.select}
                 onMouseDown={e => {
-                  if (e.target.value) {
-                    setSearchTerm(e.target.value)
-                    onChange && onChange(e.target.value)
+                  const selectedTarget = e.target.getAttribute('data-value')
+                  if (selectedTarget) {
+                    setSearchTerm(selectedTarget)
+                    onChange && onChange(selectedTarget)
                   }
                 }}
               >

--- a/source/components/input-select/styles.js
+++ b/source/components/input-select/styles.js
@@ -96,10 +96,24 @@ export default (
       outline: 'none',
       whiteSpace: 'nowrap',
       textOverflow: 'ellipsis',
-      overflow: 'scroll',
+      overflowY: 'scroll',
       maxHeight: rhythm(4),
-      ...treatments.input
+      ...treatments.input,
+
+      // Webkit (Chrome) scrollbar to be persistent
+      '::-webkit-scrollbar': {
+        width: '8px',
+      },
+
+      '::-webkit-scrollbar-track': {
+        backgroundColor: 'lightgray',
+      },
+
+      '::-webkit-scrollbar-thumb': {
+        backgroundColor: 'darkgray',
+      },
     }
+ 
   }
 
   return merge(defaultStyles, styles)

--- a/source/components/input-select/styles.js
+++ b/source/components/input-select/styles.js
@@ -102,18 +102,17 @@ export default (
 
       // Webkit (Chrome) scrollbar to be persistent
       '::-webkit-scrollbar': {
-        width: '8px',
+        width: '8px'
       },
 
       '::-webkit-scrollbar-track': {
-        backgroundColor: 'lightgray',
+        backgroundColor: 'lightgray'
       },
 
       '::-webkit-scrollbar-thumb': {
-        backgroundColor: 'darkgray',
-      },
+        backgroundColor: 'darkgray'
+      }
     }
- 
   }
 
   return merge(defaultStyles, styles)


### PR DESCRIPTION
Safari will not render options tags inside anything other than a select tag because it's technically semantically incorrect. I've had to do a bit of an overhaul of this feature and change elastic search select to a div and options to p. Incidentally this completely fixes our scrollbar issues, and will work out well in terms of compatibility with older devices. I've kept it as accessible as possible with roles, so it shouldn't be an issue with screen readers. It is a little more complex now, but apart from being less readable and a bit yuck overall I don't think this should cause us any issues.



tldr; had to change select to a div and added roles for accessibility.